### PR TITLE
add scanning scripts

### DIFF
--- a/ubi/CPAccount.json
+++ b/ubi/CPAccount.json
@@ -1,0 +1,350 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_nodeId",
+        "type": "string"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_multiAddresses",
+        "type": "string[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_ubiFlag",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "_beneficiaryAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "quota",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expiration",
+        "type": "uint256"
+      }
+    ],
+    "name": "BeneficiaryChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "ubiFlag",
+        "type": "uint8"
+      }
+    ],
+    "name": "UBIFlagChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "submitter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "taskId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "taskType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "zkType",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "proof",
+        "type": "string"
+      }
+    ],
+    "name": "UBIProofSubmitted",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "beneficiary",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "beneficiaryAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "quota",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expiration",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newBeneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newQuota",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newExpiration",
+        "type": "uint256"
+      }
+    ],
+    "name": "changeBeneficiary",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string[]",
+        "name": "newMultiaddrs",
+        "type": "string[]"
+      }
+    ],
+    "name": "changeMultiaddrs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "changeOwnerAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "newUbiFlag",
+        "type": "uint8"
+      }
+    ],
+    "name": "changeUbiFlag",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "multiAddresses",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nodeId",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_taskId",
+        "type": "string"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_taskType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "string",
+        "name": "_zkType",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_proof",
+        "type": "string"
+      }
+    ],
+    "name": "submitUBIProof",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "tasks",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "taskId",
+        "type": "string"
+      },
+      {
+        "internalType": "uint8",
+        "name": "taskType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "string",
+        "name": "zkType",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "proof",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "isSubmitted",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ubiFlag",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/ubi/CPAccount.sol
+++ b/ubi/CPAccount.sol
@@ -25,6 +25,11 @@ contract CPAccount {
 
     mapping(string => Task) public tasks;
 
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event BeneficiaryChanged(address beneficiary, uint quota, uint expiration);
+    event UBIFlagChanged(uint8 ubiFlag);
+    event UBIProofSubmitted(address indexed submitter, string taskId, uint8 taskType, string zkType, string proof);
+
     constructor(
         address _owner,
         string memory _nodeId,
@@ -48,15 +53,16 @@ contract CPAccount {
         require(msg.sender == owner, "Only owner can call this function.");
         _;
     }
+    function getOwner() public view returns (address) {
+        return owner;
+    }
 
     function changeMultiaddrs(string[] memory newMultiaddrs) public onlyOwner {
         multiAddresses = newMultiaddrs;
     }
-    function getOwner() public view returns (address) {
-        return owner;
-    }
     function changeOwnerAddress(address newOwner) public onlyOwner {
         owner = newOwner;
+        emit OwnershipTransferred(msg.sender, newOwner);
     }
 
     function changeBeneficiary(
@@ -69,12 +75,14 @@ contract CPAccount {
         quota: newQuota,
         expiration: newExpiration
         });
+
+        emit BeneficiaryChanged(newBeneficiary, newQuota, newExpiration);
     }
 
-        function changeUbiFlag(uint8 newUbiFlag) public onlyOwner {
-            ubiFlag = newUbiFlag;
-        }
-
+    function changeUbiFlag(uint8 newUbiFlag) public onlyOwner {
+        ubiFlag = newUbiFlag;
+        emit UBIFlagChanged(newUbiFlag);
+    }
 
     function submitUBIProof(string memory _taskId, uint8 _taskType, string memory _zkType, string memory _proof) public onlyOwner {
         require(!tasks[_taskId].isSubmitted, "Proof for this task is already submitted.");
@@ -85,5 +93,7 @@ contract CPAccount {
         proof: _proof,
         isSubmitted: true
         });
+
+        emit UBIProofSubmitted(msg.sender, _taskId, _taskType, _zkType, _proof);
     }
 }

--- a/ubi/CPAccount.sol
+++ b/ubi/CPAccount.sol
@@ -26,6 +26,7 @@ contract CPAccount {
     mapping(string => Task) public tasks;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event MultiaddrsChanged(string[] newMultiaddrs);
     event BeneficiaryChanged(address beneficiary, uint quota, uint expiration);
     event UBIFlagChanged(uint8 ubiFlag);
     event UBIProofSubmitted(address indexed submitter, string taskId, uint8 taskType, string zkType, string proof);
@@ -59,6 +60,8 @@ contract CPAccount {
 
     function changeMultiaddrs(string[] memory newMultiaddrs) public onlyOwner {
         multiAddresses = newMultiaddrs;
+
+        emit MultiaddrsChanged(newMultiaddrs);
     }
     function changeOwnerAddress(address newOwner) public onlyOwner {
         owner = newOwner;

--- a/ubi/scan_cp_account.py
+++ b/ubi/scan_cp_account.py
@@ -1,0 +1,49 @@
+import os
+import json
+from web3 import Web3
+
+web3 = Web3(Web3.HTTPProvider("https://saturn-rpc.swanchain.io"))
+
+
+## load ABI JSON
+def load_abi_from_json(file_path):
+    with open(file_path, "r") as file:
+        abi = json.load(file)
+    return abi
+
+
+## set up contract instance
+def load_contract_instance(cp_account_address):
+    dir = os.getcwd()
+    abi_file_path = os.path.join(dir, "ubi/CPAccount.json")
+    contract_abi = load_abi_from_json(abi_file_path)
+
+    cp_account_contract = web3.eth.contract(
+        address=cp_account_address, abi=contract_abi
+    )
+    return cp_account_contract
+
+
+def get_events_between_blocks(cp_account_address, event_name, from_block, to_block):
+    cp_account_contract = load_contract_instance(cp_account_address)
+
+    # Filter events based on the specified block range
+    event_filter = cp_account_contract.events[event_name].create_filter(
+        fromBlock=from_block,
+        toBlock=to_block,
+    )
+
+    # Get events within the block range
+    events = event_filter.get_all_entries()
+
+    return events
+
+
+print(
+    get_events_between_blocks(
+        "0x357715b93c8Ce5124c2551F368BFFB34A0B6D273",
+        "UBIProofSubmitted",
+        0,
+        web3.eth.get_block("latest").number,
+    )
+)

--- a/ubi/scan_cp_account.py
+++ b/ubi/scan_cp_account.py
@@ -41,9 +41,9 @@ def get_events_between_blocks(cp_account_address, event_name, from_block, to_blo
 
 print(
     get_events_between_blocks(
-        "0x357715b93c8Ce5124c2551F368BFFB34A0B6D273",
-        "UBIProofSubmitted",
-        0,
-        web3.eth.get_block("latest").number,
+        "0x357715b93c8Ce5124c2551F368BFFB34A0B6D273",  # CPAccount contract address
+        "UBIProofSubmitted",  # event name
+        0,  # starting block
+        web3.eth.get_block("latest").number,  # ending block
     )
 )

--- a/ubi/scan_tx.py
+++ b/ubi/scan_tx.py
@@ -1,0 +1,39 @@
+import os
+import json
+
+from web3 import Web3
+
+# Initialize a web3 instance
+web3 = Web3(Web3.HTTPProvider("https://saturn-rpc.swanchain.io"))
+
+
+## load ABI JSON
+def load_abi_from_json(file_path):
+    with open(file_path, "r") as file:
+        abi = json.load(file)
+    return abi
+
+
+## set up contract instance, since we just scanning event, we dont need a contract address, just abi is enough
+def load_contract_instance():
+    dir = os.getcwd()
+    abi_file_path = os.path.join(dir, "ubi/CPAccount.json")
+    contract_abi = load_abi_from_json(abi_file_path)
+
+    cp_account_contract = web3.eth.contract(abi=contract_abi)
+    return cp_account_contract
+
+
+def scan_tx(tx_hash):
+    cp_account_contract = load_contract_instance()
+    transaction_receipt = web3.eth.get_transaction_receipt(
+        tx_hash
+    )  ## get the tx receipt
+
+    for log in transaction_receipt["logs"]:
+        ## scan the tx event, can scan different events, just change the eventName
+        event = cp_account_contract.events.UBIProofSubmitted().process_log(log)
+        print("Decoded Event:", event)
+
+
+scan_tx("0x599b0895387c6cb48ead0658a468ac50d5719c0f15c012cfda28ee5f555909a8")

--- a/ubi/scan_tx.py
+++ b/ubi/scan_tx.py
@@ -36,4 +36,6 @@ def scan_tx(tx_hash):
         print("Decoded Event:", event)
 
 
-scan_tx("0x599b0895387c6cb48ead0658a468ac50d5719c0f15c012cfda28ee5f555909a8")
+scan_tx(
+    "0x599b0895387c6cb48ead0658a468ac50d5719c0f15c012cfda28ee5f555909a8"
+)  # submitProof tx hash


### PR DESCRIPTION
- Add events to CPAccount contract
- Wrote 2 basic python functions
  - scan_tx.py returns the proof info from a transaction hash (requires tx hash)
  - scan_cp_account.py returns all proofs from one cp account address (requires cp contract address)