### PR TITLE
store registry address in cpAccount

### DIFF
--- a/ubi/CPAccount.json
+++ b/ubi/CPAccount.json
@@ -2,11 +2,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_owner",
-        "type": "address"
-      },
-      {
         "internalType": "string",
         "name": "_nodeId",
         "type": "string"
@@ -17,13 +12,18 @@
         "type": "string[]"
       },
       {
-        "internalType": "uint8",
-        "name": "_ubiFlag",
-        "type": "uint8"
+        "internalType": "address",
+        "name": "_beneficiary",
+        "type": "address"
       },
       {
         "internalType": "address",
-        "name": "_beneficiaryAddress",
+        "name": "_worker",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_contractRegistryAddress",
         "type": "address"
       }
     ],
@@ -36,23 +36,49 @@
       {
         "indexed": false,
         "internalType": "address",
-        "name": "beneficiary",
+        "name": "previousBeneficiary",
         "type": "address"
       },
       {
         "indexed": false,
-        "internalType": "uint256",
-        "name": "quota",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "expiration",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "newBeneficiary",
+        "type": "address"
       }
     ],
     "name": "BeneficiaryChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "cpAccount",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "CPAccountDeployed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string[]",
+        "name": "newMultiaddrs",
+        "type": "string[]"
+      }
+    ],
+    "name": "MultiaddrsChanged",
     "type": "event"
   },
   {
@@ -72,19 +98,6 @@
       }
     ],
     "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "ubiFlag",
-        "type": "uint8"
-      }
-    ],
-    "name": "UBIFlagChanged",
     "type": "event"
   },
   {
@@ -111,12 +124,6 @@
       {
         "indexed": false,
         "internalType": "string",
-        "name": "zkType",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
         "name": "proof",
         "type": "string"
       }
@@ -125,23 +132,32 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousWorker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newWorker",
+        "type": "address"
+      }
+    ],
+    "name": "WorkerChanged",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "beneficiary",
     "outputs": [
       {
         "internalType": "address",
-        "name": "beneficiaryAddress",
+        "name": "",
         "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "quota",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "expiration",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -153,16 +169,6 @@
         "internalType": "address",
         "name": "newBeneficiary",
         "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "newQuota",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "newExpiration",
-        "type": "uint256"
       }
     ],
     "name": "changeBeneficiary",
@@ -199,19 +205,71 @@
   {
     "inputs": [
       {
-        "internalType": "uint8",
-        "name": "newUbiFlag",
-        "type": "uint8"
+        "internalType": "address",
+        "name": "newWorker",
+        "type": "address"
       }
     ],
-    "name": "changeUbiFlag",
+    "name": "changeWorker",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
+    "name": "contractRegistryAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBeneficiary",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMultiAddresses",
+    "outputs": [
+      {
+        "internalType": "string[]",
+        "name": "",
+        "type": "string[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "getOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWorker",
     "outputs": [
       {
         "internalType": "address",
@@ -281,11 +339,6 @@
       },
       {
         "internalType": "string",
-        "name": "_zkType",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
         "name": "_proof",
         "type": "string"
       }
@@ -317,11 +370,6 @@
       },
       {
         "internalType": "string",
-        "name": "zkType",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
         "name": "proof",
         "type": "string"
       },
@@ -336,12 +384,12 @@
   },
   {
     "inputs": [],
-    "name": "ubiFlag",
+    "name": "worker",
     "outputs": [
       {
-        "internalType": "uint8",
+        "internalType": "address",
         "name": "",
-        "type": "uint8"
+        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/ubi/CPAccount.sol
+++ b/ubi/CPAccount.sol
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
 contract CPAccount {
+    address public contractRegistryAddress;
     address public owner;
     address public worker;
     string public nodeId;
@@ -37,9 +39,10 @@ contract CPAccount {
         multiAddresses = _multiAddresses;
         beneficiary = _beneficiary;
         worker = _worker;
+        contractRegistryAddress = _contractRegistryAddress;
 
         // Register CPAccount to ContractRegistry
-        registerToContractRegistry(_contractRegistryAddress);
+        registerToContractRegistry();
 
         // Emit event to notify CPAccount deployment
         emit CPAccountDeployed(address(this), owner);
@@ -50,7 +53,7 @@ contract CPAccount {
         _;
     }
 
-    function registerToContractRegistry(address contractRegistryAddress) private {
+    function registerToContractRegistry() private {
         // Call registerCPContract function of ContractRegistry
         (bool success, ) = contractRegistryAddress.call(abi.encodeWithSignature("registerCPContract(address,address)", address(this), owner));
         require(success, "Failed to register CPContract to ContractRegistry");
@@ -99,7 +102,7 @@ contract CPAccount {
         emit WorkerChanged(worker, newWorker);
     }
 
-    function submitUBIProof(string memory _taskId, uint8 memory _taskType, string memory _proof) public onlyOwner {
+    function submitUBIProof(string memory _taskId, uint8 _taskType, string memory _proof) public onlyOwner {
         require(!tasks[_taskId].isSubmitted, "Proof for this task is already submitted.");
         tasks[_taskId] = Task({
             taskId: _taskId,


### PR DESCRIPTION
- now CPAccount stores ContractRegistry address, provided in the constructor
    - so now `registerToContractRegistry` function does not need the address param
- fix syntax in `submitUBIProof` params: `memory` is for strings and arrays so `_taskType` doesn't need it.