### PR TITLE
fix minor issues

### DIFF
--- a/hardhat/contracts/CPAccount.sol
+++ b/hardhat/contracts/CPAccount.sol
@@ -84,26 +84,20 @@ contract CPAccount {
     }
 
     function changeTaskTypes(uint8[] memory newTaskTypes) public onlyOwner {
-        taskTypes = newTaskTypes;
-
         emit TaskTypesChanged(taskTypes, newTaskTypes);
+        taskTypes = newTaskTypes;
     }
 
     function changeMultiaddrs(string[] memory newMultiaddrs) public onlyOwner {
-        multiAddresses = newMultiaddrs;
-
         emit MultiaddrsChanged(multiAddresses, newMultiaddrs);
+        multiAddresses = newMultiaddrs;
     }
 
     function changeOwnerAddress(address newOwner) public onlyOwner {
-        owner = newOwner;
-
-        // Emit event to notify ContractRegistry about owner change
-        emit OwnershipTransferred(msg.sender, newOwner);
 
         // Call changeOwner function of ContractRegistry to update owner
-        (bool success, ) = contractRegistryAddress.call(abi.encodeWithSignature("changeOwner(address,address)", address(this), newOwner));
-        require(success, "Failed to change owner in ContractRegistry");
+        // (bool success, ) = contractRegistryAddress.call(abi.encodeWithSignature("changeOwner(address,address)", address(this), newOwner));
+        // require(success, "Failed to change owner in ContractRegistry");
 
 
         // 调用 ContractRegistry 的 changeOwner 函数以更新所有者
@@ -120,6 +114,11 @@ contract CPAccount {
                 revert("Failed to change owner in ContractRegistry");
             }
         }
+
+        owner = newOwner;
+
+        // Emit event to notify ContractRegistry about owner change
+        emit OwnershipTransferred(msg.sender, newOwner);
     }
     function _getRevertMsg(bytes memory _returnData) internal pure returns (string memory) {
         if (_returnData.length < 68) return "Transaction reverted silently";

--- a/hardhat/contracts/ECPCollateral.sol
+++ b/hardhat/contracts/ECPCollateral.sol
@@ -122,7 +122,6 @@ contract ECPCollateral is Ownable {
     }
 
     function withdraw(address cpAccount, uint amount) external {
-        checkCpInfo(cpAccount);
         (bool success, bytes memory CPOwner) = cpAccount.call(abi.encodeWithSignature("getOwner()"));
         require(success, "Failed to call getOwner function of CPAccount");
         address cpOwner = abi.decode(CPOwner, (address));
@@ -130,7 +129,10 @@ contract ECPCollateral is Ownable {
         require(msg.sender == cpOwner, "Only CP's owner can withdraw the collateral funds");
         balances[cpAccount] -= int(amount);
         payable(msg.sender).transfer(amount);
+
+        checkCpInfo(cpAccount);
         emit Withdraw(msg.sender, cpAccount, amount);
+        
     }
 
     function getECPCollateralInfo() external view returns (ContractInfo memory) {

--- a/hardhat/contracts/ECPCollateralUpgradeable.sol
+++ b/hardhat/contracts/ECPCollateralUpgradeable.sol
@@ -12,10 +12,29 @@ contract ECPCollateralUpgradeable is Initializable, OwnableUpgradeable, UUPSUpgr
     uint public collateralRatio;
     uint public slashRatio;
 
+    uint private STATUS_LOCKED;
+    uint private STATUS_UNLOCKED;
+    uint private STATUS_SLASHED;
+
     mapping(address => bool) public isAdmin;
     mapping(address => int) public balances;
     mapping(address => uint) public frozenBalance;
+    mapping(address => Task) public tasks;
     mapping(address => string) public cpStatus;
+
+    struct Task {
+        address cpAccountAddress;
+        uint collateral;
+        uint status; // Status represented as a uint
+    }
+
+    struct ContractInfo {
+        uint slashedFunds;
+        uint baseCollateral;
+        uint taskBalance;
+        uint collateralRatio;
+        uint slashRatio;
+    }
 
     struct CPInfo {
         address cp;
@@ -24,12 +43,14 @@ contract ECPCollateralUpgradeable is Initializable, OwnableUpgradeable, UUPSUpgr
         string status;
     }
 
-    event Deposit(address fundingWallet, address receivingWallet, uint depositAmount);
-    event Withdraw(address fundingWallet, uint withdrawAmount);
-    event LockCollateral(address cp, uint collateralAmount);
-    event UnlockCollateral(address cp, uint collateralAmount);
-    event SlashCollateral(address cp, uint amount);
-    event DisputeProof(address disputer, string proofTx);
+    event Deposit(address indexed fundingWallet, address indexed cpAccount, uint depositAmount);
+    event Withdraw(address indexed cpOwner, address indexed cpAccount, uint withdrawAmount);
+    event CollateralLocked(address indexed cp, uint collateralAmount, address taskContractAddress);
+    event CollateralUnlocked(address indexed cp, uint collateralAmount, address taskContractAddress);
+    event CollateralSlashed(address indexed cp, uint amount, address taskContractAddress);
+    event TaskCreated(address indexed taskContractAddress, address cpAccountAddress, uint collateral);
+    event TaskStatusChanged(address indexed taskContractAddress, uint newStatus);
+    event CollateralAdjusted(address indexed cp, uint frozenAmount, uint balanceAmount, string operation);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -40,174 +61,140 @@ contract ECPCollateralUpgradeable is Initializable, OwnableUpgradeable, UUPSUpgr
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
 
+        STATUS_LOCKED = 1;
+        STATUS_UNLOCKED = 2;
+        STATUS_SLASHED = 3;
+
         isAdmin[msg.sender] = true;
         collateralRatio = 5; // set default collateralRatio
         slashRatio = 2;
     }
 
-   // Modifier to check if the caller is the admin
     modifier onlyAdmin() {
         require(isAdmin[msg.sender], "Only the admin can call this function.");
         _;
     }
 
-    function addAdmin(address newAdmin) public onlyOwner {
+    function addAdmin(address newAdmin) external onlyOwner {
         isAdmin[newAdmin] = true;
     }
 
-    function removeAdmin(address admin) public onlyOwner {
+    function removeAdmin(address admin) external onlyOwner {
         isAdmin[admin] = false;
     }
 
-    
-    struct ContractInfo {
-        uint slashedFunds;
-        uint baseCollateral;
-        uint taskBalance;
-        uint collateralRatio;
-        uint slashRatio;
+    function lockCollateral(address cp, uint collateral, address taskContractAddress) external onlyAdmin {
+        require(balances[cp] >= int(collateral), "Not enough balance for collateral");
+        balances[cp] -= int(collateral);
+        frozenBalance[cp] += collateral;
+        tasks[taskContractAddress] = Task({
+            cpAccountAddress: cp,
+            collateral: collateral,
+            status: STATUS_LOCKED
+        });
+        checkCpInfo(cp);
+        emit CollateralLocked(cp, collateral, taskContractAddress);
+        emit TaskCreated(taskContractAddress, cp, collateral);
     }
 
-    function getECPCollateralInfo() public view returns (ContractInfo memory) {
-        ContractInfo memory info;
-        info.slashedFunds = slashedFunds;
-        info.baseCollateral = baseCollateral;
-        info.taskBalance = taskBalance;
-        info.collateralRatio = collateralRatio;
-        info.slashRatio = slashRatio;
-        return info;
+    function unlockCollateral(address taskContractAddress) external onlyAdmin {
+        Task storage task = tasks[taskContractAddress];
+        uint availableAmount = frozenBalance[task.cpAccountAddress];
+        uint unlockAmount = task.collateral > availableAmount ? availableAmount : task.collateral;
+
+        frozenBalance[task.cpAccountAddress] -= unlockAmount;
+        balances[task.cpAccountAddress] += int(unlockAmount);
+        task.status = STATUS_UNLOCKED;
+        checkCpInfo(task.cpAccountAddress);
+        emit CollateralUnlocked(task.cpAccountAddress, unlockAmount, taskContractAddress);
+        emit TaskStatusChanged(taskContractAddress, STATUS_UNLOCKED);
     }
 
-    function setCollateralRatio(uint _collateralRatio) public onlyOwner {
+    function slashCollateral(address taskContractAddress) external onlyAdmin {
+        Task storage task = tasks[taskContractAddress];
+        uint slashAmount = task.collateral * slashRatio;
+        uint availableFrozen = frozenBalance[task.cpAccountAddress];
+        uint fromFrozen = slashAmount > availableFrozen ? availableFrozen : slashAmount;
+        uint fromBalance = slashAmount > fromFrozen ? slashAmount - fromFrozen : 0;
+        frozenBalance[task.cpAccountAddress] -= fromFrozen;
+        balances[task.cpAccountAddress] -= int(fromBalance);
+        slashedFunds += slashAmount;
+        task.status = STATUS_SLASHED;
+        task.collateral = task.collateral > slashAmount ? task.collateral - slashAmount : 0; 
+        checkCpInfo(task.cpAccountAddress);
+        emit CollateralSlashed(task.cpAccountAddress, slashAmount, taskContractAddress);
+        emit TaskStatusChanged(taskContractAddress, STATUS_SLASHED);
+        emit CollateralAdjusted(task.cpAccountAddress, fromFrozen, fromBalance, "Slashed");
+    }
+
+    function deposit(address cpAccount) public payable {
+        balances[cpAccount] += int(msg.value);
+        checkCpInfo(cpAccount);
+        emit Deposit(msg.sender, cpAccount, msg.value);
+    }
+
+    function withdraw(address cpAccount, uint amount) external {
+        (bool success, bytes memory CPOwner) = cpAccount.call(abi.encodeWithSignature("getOwner()"));
+        require(success, "Failed to call getOwner function of CPAccount");
+        address cpOwner = abi.decode(CPOwner, (address));
+        require(balances[cpAccount] >= int(amount), "Withdraw amount exceeds balance");
+        require(msg.sender == cpOwner, "Only CP's owner can withdraw the collateral funds");
+        balances[cpAccount] -= int(amount);
+        payable(msg.sender).transfer(amount);
+
+        checkCpInfo(cpAccount);
+        emit Withdraw(msg.sender, cpAccount, amount);
+    }
+
+    function getECPCollateralInfo() external view returns (ContractInfo memory) {
+        return ContractInfo({
+            slashedFunds: slashedFunds,
+            baseCollateral: baseCollateral,
+            taskBalance: taskBalance,
+            collateralRatio: collateralRatio,
+            slashRatio: slashRatio
+        });
+    }
+
+    function setCollateralRatio(uint _collateralRatio) external onlyOwner {
         collateralRatio = _collateralRatio;
     }
 
-    function setSlashRatio(uint _slashRatio) public onlyOwner {
+    function setSlashRatio(uint _slashRatio) external onlyOwner {
         slashRatio = _slashRatio;
     }
 
-    function setbaseCollateral(uint capacity) public onlyAdmin {
-        baseCollateral = capacity;
-    }  
+    function setBaseCollateral(uint _baseCollateral) external onlyAdmin {
+        baseCollateral = _baseCollateral;
+    }
 
-    function getBaseCollateral() public view returns (uint) {
+    function getBaseCollateral() external view returns (uint) {
         return baseCollateral;
     }
 
-    function cpInfo(address cpAddress) public view returns (CPInfo memory) {
-        CPInfo memory info;
-
-        info.cp = cpAddress;
-        info.balance = balances[cpAddress];
-        info.frozenBalance = frozenBalance[cpAddress];
-        info.status = cpStatus[cpAddress];
-
-        return info;
+    function cpInfo(address cpAddress) external view returns (CPInfo memory) {
+        return CPInfo({
+            cp: cpAddress,
+            balance: balances[cpAddress],
+            frozenBalance: frozenBalance[cpAddress],
+            status: cpStatus[cpAddress]
+        });
     }
 
     function checkCpInfo(address cpAddress) internal {
-        if (balances[cpAddress] >= int(collateralRatio*baseCollateral)) {
+        if (balances[cpAddress] >= int(collateralRatio * baseCollateral)) {
             cpStatus[cpAddress] = 'zkAuction';
         } else {
             cpStatus[cpAddress] = 'NSC';
         }
     }
 
+    function getTaskInfo(address taskContractAddress) external view returns (Task memory) {
+        return tasks[taskContractAddress];
+    }
+
     receive() external payable {
         deposit(msg.sender);
-    }
-
-    /**
-     * @notice - deposits tokens into the contract
-     */
-    function deposit(address recipient) public payable {
-        balances[recipient] += int(msg.value);
-
-        checkCpInfo(recipient);
-
-        emit Deposit(msg.sender, recipient, msg.value);
-    }
-
-    function withdraw(uint amount) public {
-        require(balances[msg.sender] >= int(amount), "Withdraw amount exceeds balance");
-
-        balances[msg.sender] -= int(amount);
-        payable(msg.sender).transfer(amount);
-
-        checkCpInfo(msg.sender);
-
-        emit Withdraw(msg.sender, amount);
-    }
-
-    function batchLockCollateral(address[] memory cpList, uint collateral) public onlyAdmin {
-        for (uint i = 0; i < cpList.length; i++) {
-            require(balances[cpList[i]] >= int(collateral), 'Not enough balance for collateral');
-        }
-
-        for (uint i = 0; i < cpList.length; i++) {
-            balances[cpList[i]] -= int(collateral);
-            frozenBalance[cpList[i]] += collateral;
-
-            checkCpInfo(cpList[i]);
-
-
-            emit LockCollateral(cpList[i], collateral);
-        }
-
-        uint totalCollateral = cpList.length * collateral;
-        taskBalance += totalCollateral;
-    }
-
-    function lockCollateral(address cp, uint collateral) public onlyAdmin {
-            require(balances[cp] >= int(collateral), 'Not enough balance for collateral');
-            balances[cp] -= int(collateral);
-            frozenBalance[cp] += collateral;
-
-            checkCpInfo(cp);
-        
-
-        uint totalCollateral = collateral;
-        taskBalance += totalCollateral;
-
-        emit LockCollateral(cp, collateral);
-    }
-    
-    function unlockCollateral(address recipient, uint amount) public onlyAdmin {
-        require(taskBalance >= amount, "Insufficient balance in task contract");
-
-        // frozen balance is non negative
-        if (frozenBalance[recipient] <= amount) {
-            amount = frozenBalance[recipient];
-        }
-        
-        taskBalance -= amount;
-        frozenBalance[recipient] -= amount;
-        balances[recipient] += int(amount);
-
-        checkCpInfo(recipient);
-
-        emit UnlockCollateral(recipient, amount);
-    }
-
-    function slashCollateral(address cp) public onlyAdmin {
-        uint slashAmount = baseCollateral * slashRatio;
-        balances[cp] -= int(slashAmount);
-
-        slashedFunds += slashAmount;
-
-        emit SlashCollateral(cp, slashAmount);
-    }
-
-    function disputeProof(string memory proofTx) public {
-        emit DisputeProof(msg.sender, proofTx);
-    }
-
-    function withdrawSlashedFunds() public onlyOwner {
-        uint amount = slashedFunds;
-        slashedFunds = 0;
-
-        payable(msg.sender).transfer(amount);
-        emit Withdraw(msg.sender, amount);
     }
 
     function _authorizeUpgrade(address newImplementation)

--- a/hardhat/contracts/contractRegistry.sol
+++ b/hardhat/contracts/contractRegistry.sol
@@ -25,7 +25,8 @@ contract ContractRegistry {
     }
 
     function changeOwner(address cpContract, address newOwner) external {
-        require(owner != address(0), "Invalid owner address");
+        require(newOwner != address(0), "Invalid owner address");
+        require(msg.sender == cpContract, "Only the CP contract can change its owner");
         cpContracts[cpContract].owner = newOwner;
 
         emit CPAddressChanged(cpContract, newOwner);


### PR DESCRIPTION
- CPAccount.sol
  - removed duplicate `changeOwner` call
  - emit event before change state variable, so that the previous value will be emitted
- ContractRegistry.sol
  - added require statement for `changeOwner`, to prevent anyone modifying the `ownerAddress` for any `cpContract`
- ECPCollateral.sol
  - call `checkCpInfo(cpAccount)` **after** the balance changes in `withdraw()` and `deposit()`

- ECPCollateralUpgradeable.sol
  - update logic to match `ECPCollateral.sol`